### PR TITLE
  OT89-443 -testimonial form with CKEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,17 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app), using the [Redux](https://redux.js.org/) and [Redux Toolkit](https://redux-toolkit.js.org/) template.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alkemyTech/OT-89-Client.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/alkemyTech/OT-89-Client/issues"
+  },
+  "homepage": "https://github.com/alkemyTech/OT-89-Client#readme"
 }

--- a/src/components/testimonials/testimonials.js
+++ b/src/components/testimonials/testimonials.js
@@ -1,0 +1,118 @@
+import React from "react";
+import { CKEditor } from "@ckeditor/ckeditor5-react";
+import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
+import apiService from "../../../services/server";
+
+export default class Novedad extends React.Component {
+  state = {
+    name: "",
+    image: "",
+    content: "",
+    id: this.props.id || null,
+  };
+
+  handleChange = (event) => {
+    const target = event.target;
+    const { name, value } = target;
+
+    this.setState({
+      [name]: value,
+    });
+  };
+
+  handleCkeditorState = (event, editor) => {
+    const data = editor.getData();
+    this.setState({
+      content: data,
+    });
+    console.log(data);
+  };
+
+  handleSubmit = (event) => {
+    const FormNovelities = {
+      name: this.state.name,
+      image: this.state.image,
+      content: this.state.content,
+
+    };
+
+    console.log("testimonios", formTestimonials);
+    apiService
+      .post("/testimonials", formTestimonials) /* Cambiar ruta segun corresponda*/
+      .then((res) => {
+        console.log(res);
+      })
+      .catch((error) => {
+        console.log(error); /* Se debe importar el alert y pasar el error */
+      });
+  };
+
+  render() {
+    return (
+      <>
+        {this.state.id ? undefined : (
+          <div className="container">
+            <div className="row">
+              <div className=" col-lg-12 col-md-12 col-xs-12">
+                <form className="mt-3" onSubmit={(e) => e.preventDefault()}>
+                  <div className="form-group mb-3">
+                    <label htmlFor="title">
+                      Titulo:
+                      <input
+                        type="text"
+                        className="form-control"
+                        value={this.state.name}
+                        onChange={this.handleChange}
+                        name="name"
+                        id="name"
+                        required
+                      />
+                    </label>
+                  </div>
+                  <div className="form-group mb-3">
+                    <label htmlFor="image">
+                      Imagen:
+                      <input
+                        type="file"
+                        className="form-control"
+                        name="image"
+                        id="image"
+                        value={this.state.image}
+                        onChange={this.handleChange}
+                        required
+                      />
+                    </label>
+                  </div>
+                  <div className="form-group mb-3">
+                    <CKEditor
+                      editor={ClassicEditor}
+                      data=""
+                      onReady={(editor) => {}}
+                      name="content"
+                      onChange={this.handleCkeditorState}
+                    />
+                  </div>
+                   <div className="form-group my-3">
+                    <button
+                      type="submit"
+                      className="btn btn-primary"
+                      onClick={this.handleSubmit}
+                    >
+                      Agregar
+                    </button>
+                    <button
+                      className="btn danger btn-danger"
+                      onClick={() => this.props.setModalAdd(false)}
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+}

--- a/src/components/testimonials/testimonials.js
+++ b/src/components/testimonials/testimonials.js
@@ -3,7 +3,7 @@ import { CKEditor } from "@ckeditor/ckeditor5-react";
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
 import apiService from "../../../services/server";
 
-export default class Novedad extends React.Component {
+export default class Testimonial extends React.Component {
   state = {
     name: "",
     image: "",

--- a/src/components/testimonials/testimonials.js
+++ b/src/components/testimonials/testimonials.js
@@ -29,7 +29,7 @@ export default class Novedad extends React.Component {
   };
 
   handleSubmit = (event) => {
-    const FormNovelities = {
+    const formTestimonials = {
       name: this.state.name,
       image: this.state.image,
       content: this.state.content,


### PR DESCRIPTION
COMO: Usuario administrador
QUIERO: Crear o editar un testimonio existente
PARA: Mantener el contenido actualizado

Criterios de aceptación: El mismo contendrá los campos Nombre (en el modelo activities es name), Imagen y Contenido. Para el contenido, utilizar la librería CKEditor. El objetivo es crear un formulario reutilizable para las acciones de edición como de creación. Para esto, deberá poder comportarse de forma diferente según recibe un objeto o no.  En el caso de no recibir un objeto, significa que está realizando una acción de creación, por lo que deberá mostrar los campos vacíos y realizar una petición POST al endpoint de creación  (/testimonials). En el caso de recibir un objeto, completar el formulario con los campos del mismo y realizar una petición PATCH al endpoint de actualización (/testimonials/:id). Este formulario se mostrará en el backoffice tanto para la creación como edición